### PR TITLE
Fix asset paths for gh-pages hosting

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,9 +4,9 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no" />
 		<title>GitHub1s</title>
-		<link rel="icon" media="(prefers-color-scheme:light)" href="/favicon-light.svg" type="image/svg+xml" />
-		<link rel="icon" media="(prefers-color-scheme:dark)" href="/favicon-dark.svg" type="image/svg+xml" />
-		<link rel="manifest" href="/manifest.json" />
+               <link rel="icon" media="(prefers-color-scheme:light)" href="favicon-light.svg" type="image/svg+xml" />
+               <link rel="icon" media="(prefers-color-scheme:dark)" href="favicon-dark.svg" type="image/svg+xml" />
+               <link rel="manifest" href="manifest.json" />
 		<style><%= spinnerStyle %></style>
 		<script><%= pageTitleScript %></script>
 		<script><%= globalScript %></script>

--- a/scripts/webpack.js
+++ b/scripts/webpack.js
@@ -100,6 +100,6 @@ const createImportMapScript = () => {
 
 export const createGlobalScript = (staticDir, devVscode) => {
 	return `globalThis.dynamicImport = (url) => import(url);
-			globalThis._VSCODE_FILE_ROOT = new URL('/${staticDir}/vscode/', window.location.origin).toString();
-			${devVscode ? createImportMapScript() : ''}`;
+                       globalThis._VSCODE_FILE_ROOT = new URL('${staticDir}/vscode/', window.location.href).toString();
+                       ${devVscode ? createImportMapScript() : ''}`;
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,7 +53,7 @@ export default (env, argv) => {
 	return {
 		mode: env.mode || 'production',
 		entry: path.resolve(import.meta.dirname, 'src/index.ts'),
-		output: { clean: true, publicPath: '/', filename: `${staticDir}/bootstrap.js` },
+		output: { clean: true, publicPath: '', filename: `${staticDir}/bootstrap.js` },
 		resolve: { extensions: ['.js', '.ts'] },
 		module: {
 			rules: [


### PR DESCRIPTION
## Summary
- use relative paths for `manifest` and favicons
- compute vscode asset root from current page
- emit relative asset paths from webpack

## Testing
- `npm test` *(fails: MaxListenersExceededWarning, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_684843b289b08320a60e3b3e51411f09