### PR TITLE
Fix CI and build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-14]
+        os: [ubuntu-latest]
         node-version: [20.x]
 
     runs-on: ${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "type": "module",
   "scripts": {
-    "build": "node scripts/build.js",
+    "build:extensions": "npm --prefix extensions/github1s run compile && npm --prefix extensions/elm-web run compile && npm --prefix extensions/nim-web run compile && npm --prefix extensions/ocaml-web run compile && npm --prefix extensions/vlang-web run compile",
+    "build": "npm run build:extensions && npx webpack --mode=production",
     "watch": "rm -rf dist && run-p watch:*",
     "watch:dev-server": "webpack serve --mode=development",
     "watch:github1s-extension": "cd extensions/github1s && npm run watch",

--- a/public/index.html
+++ b/public/index.html
@@ -4,9 +4,9 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no" />
 		<title>GitHub1s</title>
-		<link rel="icon" media="(prefers-color-scheme:light)" href="/favicon-light.svg" type="image/svg+xml" />
-		<link rel="icon" media="(prefers-color-scheme:dark)" href="/favicon-dark.svg" type="image/svg+xml" />
-		<link rel="manifest" href="/manifest.json" />
+               <link rel="icon" media="(prefers-color-scheme:light)" href="favicon-light.svg" type="image/svg+xml" />
+               <link rel="icon" media="(prefers-color-scheme:dark)" href="favicon-dark.svg" type="image/svg+xml" />
+               <link rel="manifest" href="manifest.json" />
 		<style><%= spinnerStyle %></style>
 		<script><%= pageTitleScript %></script>
 		<script><%= globalScript %></script>

--- a/scripts/webpack.js
+++ b/scripts/webpack.js
@@ -100,6 +100,6 @@ const createImportMapScript = () => {
 
 export const createGlobalScript = (staticDir, devVscode) => {
 	return `globalThis.dynamicImport = (url) => import(url);
-			globalThis._VSCODE_FILE_ROOT = new URL('/${staticDir}/vscode/', window.location.origin).toString();
-			${devVscode ? createImportMapScript() : ''}`;
+                       globalThis._VSCODE_FILE_ROOT = new URL('${staticDir}/vscode/', window.location.href).toString();
+                       ${devVscode ? createImportMapScript() : ''}`;
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,7 +53,7 @@ export default (env, argv) => {
 	return {
 		mode: env.mode || 'production',
 		entry: path.resolve(import.meta.dirname, 'src/index.ts'),
-		output: { clean: true, publicPath: '/', filename: `${staticDir}/bootstrap.js` },
+		output: { clean: true, publicPath: '', filename: `${staticDir}/bootstrap.js` },
 		resolve: { extensions: ['.js', '.ts'] },
 		module: {
 			rules: [


### PR DESCRIPTION
## Summary
- run CI on Ubuntu instead of macOS
- compile each extension directly from package.json
- keep asset paths relative for gh-pages

## Testing
- `npm test` *(fails: MaxListenersExceededWarning, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_684843b289b08320a60e3b3e51411f09