### PR TITLE
Fix CI and build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-14]
+        os: [ubuntu-latest]
         node-version: [20.x]
 
     runs-on: ${{ matrix.os }}
@@ -28,5 +28,6 @@ jobs:
       - run: npm install
       - run: npm run eslint
       - run: npm run build
-      - uses: microsoft/playwright-github-action@v1
+      - name: Install Playwright
+        run: npx playwright install --with-deps
       - run: GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} npm run test:ci

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "type": "module",
   "scripts": {
-    "build": "node scripts/build.js",
+    "build:extensions": "npm --prefix extensions/github1s run compile && npm --prefix extensions/elm-web run compile && npm --prefix extensions/nim-web run compile && npm --prefix extensions/ocaml-web run compile && npm --prefix extensions/vlang-web run compile",
+    "build": "npm run build:extensions && npx webpack --mode=production",
     "watch": "rm -rf dist && run-p watch:*",
     "watch:dev-server": "webpack serve --mode=development",
     "watch:github1s-extension": "cd extensions/github1s && npm run watch",

--- a/public/index.html
+++ b/public/index.html
@@ -4,9 +4,9 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no" />
 		<title>GitHub1s</title>
-		<link rel="icon" media="(prefers-color-scheme:light)" href="/favicon-light.svg" type="image/svg+xml" />
-		<link rel="icon" media="(prefers-color-scheme:dark)" href="/favicon-dark.svg" type="image/svg+xml" />
-		<link rel="manifest" href="/manifest.json" />
+               <link rel="icon" media="(prefers-color-scheme:light)" href="favicon-light.svg" type="image/svg+xml" />
+               <link rel="icon" media="(prefers-color-scheme:dark)" href="favicon-dark.svg" type="image/svg+xml" />
+               <link rel="manifest" href="manifest.json" />
 		<style><%= spinnerStyle %></style>
 		<script><%= pageTitleScript %></script>
 		<script><%= globalScript %></script>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "GitHub1S",
   "short_name": "GitHub1s",
-  "start_url": "/",
+  "start_url": "./",
   "lang": "en-US",
   "display": "standalone"
 }

--- a/scripts/webpack.js
+++ b/scripts/webpack.js
@@ -100,6 +100,6 @@ const createImportMapScript = () => {
 
 export const createGlobalScript = (staticDir, devVscode) => {
 	return `globalThis.dynamicImport = (url) => import(url);
-			globalThis._VSCODE_FILE_ROOT = new URL('/${staticDir}/vscode/', window.location.origin).toString();
-			${devVscode ? createImportMapScript() : ''}`;
+                       globalThis._VSCODE_FILE_ROOT = new URL('${staticDir}/vscode/', window.location.href).toString();
+                       ${devVscode ? createImportMapScript() : ''}`;
 };

--- a/vscode-web/index.html
+++ b/vscode-web/index.html
@@ -4,18 +4,18 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no" />
 		<title>VSCode Web</title>
-		<link rel="icon" href="/favicon.ico" type="image/x-icon" />
-		<link rel="stylesheet" href="/vscode/vs/workbench/workbench.web.main.css" />
+               <link rel="icon" href="favicon.ico" type="image/x-icon" />
+               <link rel="stylesheet" href="vscode/vs/workbench/workbench.web.main.css" />
 	</head>
 	<body>
-		<script src="/vscode/nls.messages.js"></script>
-		<script>
-			globalThis._VSCODE_FILE_ROOT = new URL('/vscode/', window.location.origin).toString();
-		</script>
-		<script type="module">
-			import { create, URI } from '/vscode/vs/workbench/workbench.web.main.internal.js';
-			create(document.body, {
-				webviewEndpoint: '/vscode/vs/workbench/contrib/webview/browser/pre',
+               <script src="vscode/nls.messages.js"></script>
+               <script>
+                       globalThis._VSCODE_FILE_ROOT = new URL('vscode/', window.location.href).toString();
+               </script>
+               <script type="module">
+                       import { create, URI } from 'vscode/vs/workbench/workbench.web.main.internal.js';
+                       create(document.body, {
+                               webviewEndpoint: 'vscode/vs/workbench/contrib/webview/browser/pre',
 				workspaceProvider: {
 					workspace: { workspaceUri: URI.from({ scheme: 'tmp', path: '/default.code-workspace' }) },
 				},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,7 +53,7 @@ export default (env, argv) => {
 	return {
 		mode: env.mode || 'production',
 		entry: path.resolve(import.meta.dirname, 'src/index.ts'),
-		output: { clean: true, publicPath: '/', filename: `${staticDir}/bootstrap.js` },
+		output: { clean: true, publicPath: '', filename: `${staticDir}/bootstrap.js` },
 		resolve: { extensions: ['.js', '.ts'] },
 		module: {
 			rules: [


### PR DESCRIPTION
## Summary
- run CI on Ubuntu instead of macOS
- compile each extension directly from package.json
- keep asset paths relative for gh-pages
- install Playwright with the CLI in CI
- serve vscode-web assets relative to the current directory
- use a relative start URL in the PWA manifest

## Testing
- `npm test` *(fails: MaxListenersExceededWarning, network blocked)*

------
https://chatgpt.com/codex/tasks/task_b_684843b289b08320a60e3b3e51411f09