### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,3 +31,8 @@ jobs:
       - name: Install Playwright
         run: npx playwright install --with-deps
       - run: GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} npm run test:ci
+      - name: Upload dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy to GitHub Pages
+
+on:
+  workflow_run:
+    workflows: ['Build & Test']
+    types:
+      - completed
+    branches:
+      - master
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: dist
+          path: ./dist
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./dist


### PR DESCRIPTION
## Summary
- upload `dist` from the build job as an artifact
- create `deploy.yml` that publishes the artifact to the `gh-pages` branch
- fix artifact download configuration so deploy job grabs the previous run's output

## Testing
- `npm test` *(fails: unable to reach registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_b_684b9ffc70288320b44a15c4b4a8e9be